### PR TITLE
Minor fixes - SeretoDate, plugin loading

### DIFF
--- a/sereto/cli/cli.py
+++ b/sereto/cli/cli.py
@@ -876,8 +876,8 @@ def load_plugins() -> None:
 
             # Execute the module to initialize it
             spec.loader.exec_module(module)
-        except ModuleNotFoundError:
-            Console().log(f"Plugin module not found: {file.name}")
+        except ModuleNotFoundError as e:
+            Console().log(f"Plugin module '{e.name}' not found: '{file.name}'")
             continue
 
         # Run the plugin's register_commands function

--- a/sereto/models/date.py
+++ b/sereto/models/date.py
@@ -33,8 +33,8 @@ class SeretoDate(RootModel[date]):
                 raise ValueError("invalid type, use string or date")
 
     @classmethod
-    def from_str(cls, v: str) -> "SeretoDate":
-        date = datetime.strptime(v, r"%d-%b-%Y").date()
+    def from_str(cls, v: str, fmt: str = r"%d-%b-%Y") -> "SeretoDate":
+        date = datetime.strptime(v, fmt).date()
         return cls.model_construct(root=date)
 
     @field_serializer("root")


### PR DESCRIPTION
Two minor changes:
- allow construction of SeretoDate class from a custom format string
- when loading plugins and a Python module is missing, print its name