### PR TITLE
CI: Set job permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,13 @@
 name: Pages
+
 on:
   push:
     branches:
       - main
+
 permissions:
-  contents: write
+  pages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,10 @@ jobs:
     name: Build distribution 📦
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      actions: write   # upload-artifact
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -34,8 +38,10 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/sereto
+
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write   # OIDC for pypa/gh-action-pypi-publish
+      actions: read     # download-artifact
 
     steps:
     - name: Download all the dists
@@ -55,8 +61,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
+      contents: write   # create GitHub Release
+      id-token: write   # sigstore
+      actions: read     # download-artifact
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,4 +1,6 @@
 name: Tox
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,11 +1,13 @@
 name: Tox
-permissions:
-  contents: read
+
 on:
   push:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- CI: Set job permissions
+
 ## [0.2.6] - 2025-05-23
 
 ### Added


### PR DESCRIPTION
Potential fix for [https://github.com/s3r3t0/sereto/security/code-scanning/3](https://github.com/s3r3t0/sereto/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read repository contents (e.g., to check out the code), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
