### PR TITLE
updated output filenames for sow.pdf and report.pdf

### DIFF
--- a/sereto/cli/cli.py
+++ b/sereto/cli/cli.py
@@ -542,7 +542,7 @@ def open_report(ctx: Project, version: ProjectVersion | None) -> None:
     if version is None:
         version = ctx.config.last_version
 
-    if not (report_path := ctx.path / "pdf" / f"report{version.path_suffix}.pdf").is_file():
+    if not (report_path := ctx.path / "pdf" / f"{ctx.path.name} - Report {version.path_suffix}.pdf").is_file():
         raise SeretoPathError(f"File not found '{report_path}'")
 
     click.launch(str(report_path))
@@ -563,7 +563,7 @@ def open_sow(ctx: Project, version: ProjectVersion | None) -> None:
     if version is None:
         version = ctx.config.last_version
 
-    if not (sow_path := ctx.path / "pdf" / f"sow{version.path_suffix}.pdf").is_file():
+    if not (sow_path := ctx.path / "pdf" / f"{ctx.path.name} - Statement of Work {version.path_suffix}.pdf").is_file():
         raise SeretoPathError(f"File not found '{sow_path}'")
 
     click.launch(str(sow_path))

--- a/sereto/pdf.py
+++ b/sereto/pdf.py
@@ -154,7 +154,8 @@ def generate_pdf_report(
         pdf_dir.mkdir()
 
     # Move the report PDF to the "pdf" directory
-    report_pdf = report_pdf.rename(project.path / "pdf" / report_pdf.name)
+    updated_filename=f"{project.path.name} - Report {version.path_suffix}.pdf"
+    report_pdf = report_pdf.rename(project.path / "pdf" / updated_filename)
 
     return report_pdf
 
@@ -192,7 +193,8 @@ def generate_pdf_sow(project: Project, sow_recipe: str | None, version: ProjectV
         pdf_dir.mkdir()
 
     # Move the SoW PDF to the "pdf" directory
-    sow_pdf = sow_pdf.rename(project.path / "pdf" / sow_pdf.name)
+    updated_filename=f"{project.path.name} - Statement of Work {version.path_suffix}.pdf"
+    sow_pdf = sow_pdf.rename(project.path / "pdf" / updated_filename)
 
     return sow_pdf
 


### PR DESCRIPTION
Changed output filenames during PDF file generation and updated the open command accordingly.
New filename format:
Report: {id} - Report {version}.pdf
SoW: {id} - Statement of Work {version}.pdf
