### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-- Update textual requirement from ~=8.0.0 to ~=8.2.3
-- Update pypdf requirement from ~=6.8.0 to ~=6.9.2
-- Update sereto-repl requirement from ~=0.3.1 to ~=0.3.2
 - Update click requirement from ~=8.1.7 to ~=8.3.1
-- Bump cryptography from 46.0.5 to 46.0.6
-- Bump requests from 2.32.5 to 2.33.0
-- Bump pygments from 2.19.2 to 2.20.0
+- Update jinja2 requirement from ~=3.1.4 to ~=3.1.6
+- Update pathspec requirement from >=0.12.1 to ~=1.0.4
+- Update prompt-toolkit requirement from ~=3.0.50 to ~=3.0.52
+- Update pydantic-settings requirement from ~=2.13.0 to ~=2.13.1
+- Update pypdf requirement from ~=6.8.0 to ~=6.10.0
+- Update rapidfuzz requirement from ~=3.14.0 to ~=3.14.5
+- Update sereto-repl requirement from ~=0.3.1 to ~=0.3.2
+- Update textual requirement from ~=8.0.0 to ~=8.2.3
 - Bump aiohttp from 3.13.3 to 3.13.4
+- Bump cryptography from 46.0.5 to 46.0.7
+- Bump pillow from 12.1.1 to 12.2.0
+- Bump pygments from 2.19.2 to 2.20.0
+- Bump requests from 2.32.5 to 2.33.0
 
 ## [0.6.0] - 2026-03-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "pydantic-settings~=2.13.1",
   "pydantic[email]",
   "pydantic~=2.12.4",
-  "pypdf~=6.9.0",
+  "pypdf~=6.10.0",
   "python-frontmatter~=1.1.0",
   "rapidfuzz~=3.14.5",
   "rich~=14.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1683,11 +1683,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.9.2"
+version = "6.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/9f/ca96abf18683ca12602065e4ed2bec9050b672c87d317f1079abc7b6d993/pypdf-6.10.0.tar.gz", hash = "sha256:4c5a48ba258c37024ec2505f7e8fd858525f5502784a2e1c8d415604af29f6ef", size = 5314833, upload-time = "2026-04-10T09:34:57.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f2/7ebe366f633f30a6ad105f650f44f24f98cb1335c4157d21ae47138b3482/pypdf-6.10.0-py3-none-any.whl", hash = "sha256:90005e959e1596c6e6c84c8b0ad383285b3e17011751cedd17f2ce8fcdfc86de", size = 334459, upload-time = "2026-04-10T09:34:54.966Z" },
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.12.4" },
     { name = "pydantic", extras = ["email"] },
     { name = "pydantic-settings", specifier = "~=2.13.0" },
-    { name = "pypdf", specifier = "~=6.9.0" },
+    { name = "pypdf", specifier = "~=6.10.0" },
     { name = "python-frontmatter", specifier = "~=1.1.0" },
     { name = "rapidfuzz", specifier = "~=3.14.5" },
     { name = "rich", specifier = "~=14.3.1" },


### PR DESCRIPTION
- Bring changelog up-to-date with dependencies updates
- Update pypdf manually to preserve `~=` syntax