### PR TITLE
Refactor aliases to take into account their position

### DIFF
--- a/sereto/cli/utils.py
+++ b/sereto/cli/utils.py
@@ -28,8 +28,9 @@ class AliasedGroup(click.Group):
         if rv is not None:
             return rv
 
-        # look up an explicit command alias
-        if cmd_name in cli_aliases:
+        # if command is on the first position (has no context parent), check for explicit alias
+        if ctx.parent is None and cmd_name in cli_aliases:
+            # look up an explicit command alias
             actual_cmd = cli_aliases[cmd_name]
             return click.Group.get_command(self, ctx, actual_cmd)
 


### PR DESCRIPTION
Refactored the logic of evaluating aliases based on their position, for example:

- if `c` is first command => `c` is evaluated as `config` no matter what
- if `c`  is second+ command  => `c` is evaluated by unique match

So the check for explicit alias declared in `aliases.py` is taken into account only if the command is the first one (besides `sereto`)