### PR TITLE
Fix loading of config

### DIFF
--- a/sereto/models/target.py
+++ b/sereto/models/target.py
@@ -86,8 +86,8 @@ class TargetDastModel(TargetModel):
     ip_allowed: bool | None = None
     authentication: bool = False
     credentials_provided: bool | None = None
-    exposure: TargetExposure = TargetExposure.external
-    environment: Environment = Environment.acceptance
+    exposure: TargetExposure = Field(strict=False, default=TargetExposure.external)
+    environment: Environment = Field(strict=False, default=Environment.acceptance)
     waf_present: bool = False
     waf_whitelisted: bool | None = None
     clickpath: str | None = None


### PR DESCRIPTION
Since we started loading into specific types of `TargetModel`s, loading DAST target (`TargetDastModel`) failed because of strict parsing of `str` into `enum`.